### PR TITLE
Have rather blog name than author in titles

### DIFF
--- a/en.ini
+++ b/en.ini
@@ -798,4 +798,4 @@ name = Mike Zamansky
 name = Toby 'qubit' Cubitt
 
 [https://www.eigenbahn.com/atom.emacs.xml]
-name = Jordan Besly
+name = Eigenbahn


### PR DESCRIPTION
Hi,

I went a bit too fast and didn't realize that the `name` field would appear in each post title. 

I thought it corresponded to author name and would be more discreet.

I would rather have the blog appear (like Irreal and Emacs Redux do) rather than the author name.